### PR TITLE
[Delivers #8] Breaking: Upgrade to RxJS 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "watch": "0.18.0"
   },
   "dependencies": {
-    "rx": "4.1.0"
+    "rxjs": "^5.0.0-beta.11"
   }
 }

--- a/source/ogen.js
+++ b/source/ogen.js
@@ -1,4 +1,4 @@
-const Rx = require('rx');
+const Rx = require('rxjs/Rx');
 
 /* eslint-disable no-use-before-define */
 if (typeof setImmediate !== 'function') {
@@ -15,24 +15,24 @@ const next = (iter, observer, prev = undefined) => {
   try {
     item = iter.next(prev);
   } catch (err) {
-    return observer.onError(err);
+    return observer.error(err);
   }
 
   const value = item.value;
 
   if (item.done) {
-    return observer.onCompleted();
+    return observer.complete();
   }
 
   if (isPromise(value)) {
     value.then(val => {
-      observer.onNext(val);
+      observer.next(val);
       setImmediate(() => next(iter, observer, val));
     }).catch(err => {
-      return observer.onError(err);
+      return observer.error(err);
     });
   } else {
-    observer.onNext(value);
+    observer.next(value);
     setImmediate(() => next(iter, observer, value));
   }
 };

--- a/source/test/index.js
+++ b/source/test/index.js
@@ -78,9 +78,9 @@ test('with arguments', assert => {
 });
 
 test('rejected promise', assert => {
-  const msg = 'should notify onError';
+  const msg = 'should notify on error';
   const halt = 'should not emit more data';
-  const noComplete = 'should not notify onCompleted';
+  const noComplete = 'should not notify on complete';
 
   const fetchSomething = () => new Promise((x, reject) => {
     setTimeout(() =>
@@ -111,9 +111,9 @@ test('rejected promise', assert => {
 
 
 test('promise throw', assert => {
-  const msg = 'should notify onError';
+  const msg = 'should notify on error';
   const halt = 'should not emit more data';
-  const noComplete = 'should not notify onCompleted';
+  const noComplete = 'should not notify on complete';
 
   const fetchSomething = () => new Promise(() => {
     throw new Error('Could not fetch data');
@@ -142,9 +142,9 @@ test('promise throw', assert => {
 });
 
 test('generator throw', assert => {
-  const msg = 'should notify onError';
+  const msg = 'should notify on error';
   const halt = 'should not emit more data';
-  const noComplete = 'should not notify onCompleted';
+  const noComplete = 'should not notify on complete';
 
   const generator = function* () {
     throw new Error('faulty generator');


### PR DESCRIPTION
RxJS 5 supports the new observer specification as proposed for ESNext. This is a breaking change.

For migration help, see [rxjs/Migration](https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md).
